### PR TITLE
Various fixes for ordered_yaml

### DIFF
--- a/modules/wmflib/lib/puppet/parser/functions/ordered_yaml.rb
+++ b/modules/wmflib/lib/puppet/parser/functions/ordered_yaml.rb
@@ -26,7 +26,6 @@ def sort_keys_recursive(value)
     end
     value.sort.reduce(map) { |h, (k, v)| h[k] = sort_keys_recursive(v); h }
   when 'true', 'false'
-    value == 'true'
   when :undef
     nil
   else

--- a/modules/wmflib/lib/puppet/parser/functions/ordered_yaml.rb
+++ b/modules/wmflib/lib/puppet/parser/functions/ordered_yaml.rb
@@ -5,7 +5,7 @@
 # === Examples
 #
 #   # Render a Puppet hash as a configuration file:
-#   $options = { 'useGraphite' => true, 'minVal' => '0.1' }
+#   $options = { 'useGraphite' => true, 'minVal' => 0.1 }
 #   file { '/etc/kibana/config.yaml':
 #     content => ordered_yaml($options),
 #   }
@@ -25,11 +25,10 @@ def sort_keys_recursive(value)
       map.sort.each { |p| yield p }
     end
     value.sort.reduce(map) { |h, (k, v)| h[k] = sort_keys_recursive(v); h }
-  when 'true', 'false'
   when :undef
     nil
   else
-    value.include?('.') ? Float(value) : Integer(value) rescue value
+    value
   end
 end
 


### PR DESCRIPTION
Hey!

I did steal your ordered_yaml implementation but I did notice two bugs:

 - when using "false", we get "true"
 - when passing a string, it is tried as a boolean, as an integer or as a float

I did two commits as I am pretty sure the first one corrects a bug. However, I suppose that the behaviour corrected by the second one was a wanted behaviour (reflected also in the example). Feel free to discard it. The commit message contains some rationale on why I think this is a bad idea to do this kind of implicit conversions.